### PR TITLE
update docker image version in example to avoid docker vulnerability

### DIFF
--- a/automated_provisioning/sample_job/job.yml
+++ b/automated_provisioning/sample_job/job.yml
@@ -2,7 +2,7 @@ experiment_name: Test-FL-Auto-Provisioning
 code:
   local_path: ./src
 command: python train.py --data-folder {inputs.mnist} --regularization 0.6
-environment: azureml:AzureML-sklearn-0.24-ubuntu18.04-py37-cpu:20
+environment: azureml:AzureML-sklearn-0.24-ubuntu18.04-py37-cpu:24
 compute: azureml:cont-01-compute # adjust the compute name accordingly
 inputs:
   mnist:


### PR DESCRIPTION
update docker image version in example to avoid docker vulnerability (S360 Alerts). 

Context: image "AzureML-sklearn-0.24-ubuntu18.04-py37-cpu:20" is no longer the latest version and will throw out S360 alerts, update it to the latest version which is 24.