### PR TITLE
Secure internal silos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,6 @@ dmypy.json
 
 # if you use an AzureML config file locally
 config.json
+
+mlops/internal_silos/YAML/setup_info_local.yml
+examples/pipelines/test_job

--- a/mlops/internal_silos/YAML/setup_info.yml
+++ b/mlops/internal_silos/YAML/setup_info.yml
@@ -1,16 +1,22 @@
 subscription_id: <Your-SubscriptionId>
 workspace:
-  name: vanilla-fl 
+  name: thopo-vanilla-fl-2
   region: westus2
-  resource_group: vanilla-fl-rg
+  resource_group: thopo-vanilla-fl-2-rg
   orchestrator_compute_name: cpu-cluster
 silos:
   - silo_01:
     name: silo-wus2
     region: westus2
+    storage_account: thopostaccwus2test
+    container: mnist
   - silo_02:
     name: silo-eus2
     region: eastus2
+    storage_account: thopostacceus2test
+    container: mnist
   - silo_03:
     name: silo-weu
-    region: westeurope       
+    region: westeurope
+    storage_account: thopostaccweutest
+    container: mnist   

--- a/mlops/internal_silos/YAML/setup_info.yml
+++ b/mlops/internal_silos/YAML/setup_info.yml
@@ -1,8 +1,8 @@
 subscription_id: <Your-SubscriptionId>
 workspace:
-  name: thopo-vanilla-fl-2
+  name: vanilla-fl
   region: westus2
-  resource_group: thopo-vanilla-fl-2-rg
+  resource_group: vanilla-fl-rg
   orchestrator_compute_name: cpu-cluster
 silos:
   - silo_01:

--- a/mlops/internal_silos/ps/SecureVanillaSetup.ps1
+++ b/mlops/internal_silos/ps/SecureVanillaSetup.ps1
@@ -1,0 +1,86 @@
+
+# 0. Extract setup information, load dependencies, set subscription
+# 0.a Read the YAML file
+[string[]]$fileContent = Get-Content "./YAML/setup_info.yml"
+$content = ''
+foreach ($line in $fileContent) { $content = $content + "`n" + $line }
+$yaml = ConvertFrom-YAML $content
+# 0.b Collect the values from the YAML file
+$SubscriptionId = $yaml['subscription_id']
+$WorkspaceName = $yaml['workspace']['name']
+$WorkspaceResourceGroup = $yaml['workspace']['resource_group']
+$Silos = $yaml['silos']
+$NumSilos = $Silos.Count
+# 0.c Display summary of what will be created
+# 0.c.ii Per-silo summary
+# 0.d Load useful functions
+. "$PSScriptRoot/../../external_silos/ps/AzureUtilities.ps1"
+# 0.e Log in and make sure we're in the right subscription
+az login
+az account set --subscription $SubscriptionId
+
+
+# SECURE TRAINING INPUTS
+$SiloIndex = 1
+foreach ($Silo in $Silos)
+{
+    $SiloName = $Silo['name']
+    $SiloRegion = $Silo['region']
+    $SiloInputStorageAccount = $Silo['storage_account']
+    $SiloContainer = $Silo['container']
+    $SiloDatastoreName = $SiloName.replace('-', '') + "ds"
+    Write-Output "Securing silo '$SiloName'..."
+    # 1. create silo input datastore
+    Write-Output "Creating input datastore '$SiloDatastoreName'"
+    # 1.1 build the definition in YAML 
+    $DatastoreYAML="`$schema: https://azuremlschemas.azureedge.net/latest/azureBlob.schema.json
+name: $SiloDatastoreName
+type: azure_blob
+description: Credential-less datastore pointing to a blob container.
+account_name: $SiloInputStorageAccount
+container_name: $SiloContainer"
+    # 1.2 write the YAML
+    $DatastoreYAML | Out-File -FilePath ./datastore.yml
+    # 1.3 use the CLI to create the datastore
+    az ml datastore create --file datastore.yml --resource-group $WorkspaceResourceGroup --workspace-name $WorkspaceName
+    # 1.4 delete the temporary YAML file
+    Remove-Item -Path ./datastore.yml
+    
+    # 2. create data assets
+    Write-Output "Creating data assets"
+    # 2.1 build the definitions in YAML
+    $TrainingDataYAML="`$schema: https://azuremlschemas.azureedge.net/latest/data.schema.json
+name: mnist-train-$SiloRegion
+description: Data asset created from file in cloud.
+type: uri_file
+path: azureml://datastores/$SiloDatastoreName/paths/train.csv" # adjust path and type accordingly
+    $TestDataYAML="`$schema: https://azuremlschemas.azureedge.net/latest/data.schema.json
+name: mnist-test-$SiloRegion
+description: Data asset created from file in cloud.
+type: uri_file
+path: azureml://datastores/$SiloDatastoreName/paths/t10k.csv" # adjust path and type accordingly
+    # 2.2 write the YAML's into 2 files
+    $TrainingDataYAML | Out-File -FilePath ./mnist_train.yml
+    $TestDataYAML | Out-File -FilePath ./mnist_test.yml
+    # 2.3 use the CLI to create the data assets
+    az ml data create --file ./mnist_train.yml --resource-group $WorkspaceResourceGroup --workspace-name $WorkspaceName --subscription $SubscriptionId
+    az ml data create --file ./mnist_test.yml --resource-group $WorkspaceResourceGroup --workspace-name $WorkspaceName --subscription $SubscriptionId
+    # 2.4 and finally we delete the temporary files
+    Remove-Item -Path ./mnist_train.yml
+    Remove-Item -Path ./mnist_test.yml
+    
+    # 3. create a user-assigned managed identity
+    $SiloIdentityName = $SiloName + "-identity"
+    Write-Output "Creating user-assigned identity '$SiloIdentityName'"
+    az identity create --name $SiloIdentityName --resource-group $WorkspaceResourceGroup --location $SiloRegion --subscription $SubscriptionId
+
+    # 4. give managed identity to the silo compute
+    $SiloComputeName = "cpu-" + $SiloName
+    Write-Output "Giving the user-assigned identity '$SiloIdentityName' to silo compute '$SiloComputeName'"
+    $IdentityResourceId = "/subscriptions/$SubscriptionId/resourcegroups/$WorkspaceResourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/$SiloIdentityName"
+    az ml compute update --name $SiloComputeName --resource-group $WorkspaceResourceGroup --workspace-name $WorkspaceName --identity-type UserAssigned --user-assigned-identities $IdentityResourceId --subscription $SubscriptionId
+
+    # Increment the silo index to keep it accurate
+    Write-Output "Done securing silo '$SiloName'."
+    $SiloIndex=$SiloIndex+1
+}

--- a/mlops/internal_silos/ps/SecureVanillaSetup.ps1
+++ b/mlops/internal_silos/ps/SecureVanillaSetup.ps1
@@ -16,7 +16,7 @@ $NumSilos = $Silos.Count
 # 0.d Load useful functions
 . "$PSScriptRoot/../../external_silos/ps/AzureUtilities.ps1"
 # 0.e Log in and make sure we're in the right subscription
-az login
+az login --output none
 az account set --subscription $SubscriptionId
 
 
@@ -30,50 +30,84 @@ foreach ($Silo in $Silos)
     $SiloContainer = $Silo['container']
     $SiloDatastoreName = $SiloName.replace('-', '') + "ds"
     Write-Output "Securing silo '$SiloName'..."
-    # 1. create silo input datastore
-    Write-Output "Creating input datastore '$SiloDatastoreName'"
-    # 1.1 build the definition in YAML 
-    $DatastoreYAML="`$schema: https://azuremlschemas.azureedge.net/latest/azureBlob.schema.json
+
+    # 1. create silo input datastore if it does not exist already
+    $MatchingSiloDatastores = az ml datastore list --resource-group $WorkspaceResourceGroup --workspace-name $WorkspaceName --query "[?name=='$SiloDatastoreName']"  | ConvertFrom-Json
+    if ($MatchingSiloDatastores.Length -eq 0){
+        Write-Output "Creating silo input datastore '$SiloDatastoreName'..."
+        # 1.1 build the definition in YAML 
+        $DatastoreYAML="`$schema: https://azuremlschemas.azureedge.net/latest/azureBlob.schema.json
 name: $SiloDatastoreName
 type: azure_blob
 description: Credential-less datastore pointing to a blob container.
 account_name: $SiloInputStorageAccount
 container_name: $SiloContainer"
-    # 1.2 write the YAML
-    $DatastoreYAML | Out-File -FilePath ./datastore.yml
-    # 1.3 use the CLI to create the datastore
-    az ml datastore create --file datastore.yml --resource-group $WorkspaceResourceGroup --workspace-name $WorkspaceName
-    # 1.4 delete the temporary YAML file
-    Remove-Item -Path ./datastore.yml
+        # 1.2 write the YAML
+        $DatastoreYAML | Out-File -FilePath ./datastore.yml
+        # 1.3 use the CLI to create the datastore
+        az ml datastore create --file datastore.yml --resource-group $WorkspaceResourceGroup --workspace-name $WorkspaceName
+        # 1.4 delete the temporary YAML file
+        Remove-Item -Path ./datastore.yml
+    }
+    else {
+        Write-Output "Silo input datastore '$SiloDatastoreName' already exists."
+    }
     
-    # 2. create data assets
-    Write-Output "Creating data assets"
-    # 2.1 build the definitions in YAML
-    $TrainingDataYAML="`$schema: https://azuremlschemas.azureedge.net/latest/data.schema.json
-name: mnist-train-$SiloRegion
+    # 2. create data assets if they don't exist already
+    # 2.a. Training
+    $TrainingDatasetName = "mnist-train-$SiloRegion"
+    $MatchingTrainingDatasets = az ml data list --resource-group $WorkspaceResourceGroup --workspace-name $WorkspaceName --query "[?name=='$TrainingDatasetName']"  | ConvertFrom-Json
+    if ($MatchingTrainingDatasets.Length -eq 0){
+        Write-Output "Creating training data asset '$TrainingDatasetName'..."
+        # 2.a.1 build the definitions in YAML
+        $TrainingDataYAML="`$schema: https://azuremlschemas.azureedge.net/latest/data.schema.json
+name: $TrainingDatasetName
 description: Data asset created from file in cloud.
 type: uri_file
 path: azureml://datastores/$SiloDatastoreName/paths/train.csv" # adjust path and type accordingly
-    $TestDataYAML="`$schema: https://azuremlschemas.azureedge.net/latest/data.schema.json
-name: mnist-test-$SiloRegion
+        # 2.a.2 write the YAML's into 2 files
+        $TrainingDataYAML | Out-File -FilePath ./mnist_train.yml
+        # 2.a.3 use the CLI to create the data assets
+        az ml data create --file ./mnist_train.yml --resource-group $WorkspaceResourceGroup --workspace-name $WorkspaceName --subscription $SubscriptionId
+        # 2.a.4 and finally we delete the temporary files
+        Remove-Item -Path ./mnist_train.yml
+    }
+    else {
+        Write-Output "Training data asset '$TrainingDatasetName' already exists."
+    }
+    # 2.b. Test
+    $TestDatasetName = "mnist-test-$SiloRegion"
+    $MatchingTestDatasets = az ml data list --resource-group $WorkspaceResourceGroup --workspace-name $WorkspaceName --query "[?name=='$TestDatasetName']"  | ConvertFrom-Json
+    if ($MatchingTestDatasets.Length -eq 0){
+        Write-Output "Creating test data asset '$TestDatasetName'..."
+        # 2.b.1 build the definitions in YAML
+        $TestDataYAML="`$schema: https://azuremlschemas.azureedge.net/latest/data.schema.json
+name: $TestDatasetName
 description: Data asset created from file in cloud.
 type: uri_file
 path: azureml://datastores/$SiloDatastoreName/paths/t10k.csv" # adjust path and type accordingly
-    # 2.2 write the YAML's into 2 files
-    $TrainingDataYAML | Out-File -FilePath ./mnist_train.yml
-    $TestDataYAML | Out-File -FilePath ./mnist_test.yml
-    # 2.3 use the CLI to create the data assets
-    az ml data create --file ./mnist_train.yml --resource-group $WorkspaceResourceGroup --workspace-name $WorkspaceName --subscription $SubscriptionId
-    az ml data create --file ./mnist_test.yml --resource-group $WorkspaceResourceGroup --workspace-name $WorkspaceName --subscription $SubscriptionId
-    # 2.4 and finally we delete the temporary files
-    Remove-Item -Path ./mnist_train.yml
-    Remove-Item -Path ./mnist_test.yml
+        # 2.b.2 write the YAML's into 2 files
+        $TestDataYAML | Out-File -FilePath ./mnist_test.yml
+        # 2.b.3 use the CLI to create the data assets
+        az ml data create --file ./mnist_test.yml --resource-group $WorkspaceResourceGroup --workspace-name $WorkspaceName --subscription $SubscriptionId
+        # 2.b.4 and finally we delete the temporary files
+        Remove-Item -Path ./mnist_test.yml
+    }
+    else {
+        Write-Output "Training data asset '$TestDatasetName' already exists."
+    }
     
-    # 3. create a user-assigned managed identity
+    # 3. create a user-assigned managed identity if it does not exist already
     $SiloIdentityName = $SiloName + "-identity"
-    Write-Output "Creating user-assigned identity '$SiloIdentityName'"
-    az identity create --name $SiloIdentityName --resource-group $WorkspaceResourceGroup --location $SiloRegion --subscription $SubscriptionId
-
+    $MatchingIdentities = az identity list --resource-group $WorkspaceResourceGroup --query "[?name=='$SiloIdentityName']"  | ConvertFrom-Json
+    if ($MatchingIdentities.Length -eq 0){
+        Write-Output "Creating user-assigned identity '$SiloIdentityName'..."
+        az identity create --name $SiloIdentityName --resource-group $WorkspaceResourceGroup --location $SiloRegion --subscription $SubscriptionId
+    }
+    else {
+        Write-Output "Identity '$SiloIdentityName' already exists."
+    }
+    
     # 4. give managed identity to the silo compute
     $SiloComputeName = "cpu-" + $SiloName
     Write-Output "Giving the user-assigned identity '$SiloIdentityName' to silo compute '$SiloComputeName'"
@@ -82,5 +116,6 @@ path: azureml://datastores/$SiloDatastoreName/paths/t10k.csv" # adjust path and 
 
     # Increment the silo index to keep it accurate
     Write-Output "Done securing silo '$SiloName'."
+    Write-Output ""
     $SiloIndex=$SiloIndex+1
 }


### PR DESCRIPTION
## Purpose
* This PR introduces a PowerShell script to secure a vanilla FL setup that was created with the `ProvisionVanillaSetup.ps1` script.
* By "secure a vanilla setup" I mean the following:
  * create and assign to the orchestrator compute a managed identity;
  * for each silo, do the following:
    * create and assign to the silo compute a managed identity;
    * create a datastore for reading the silo input data from a pre-existing storage account;
    * create data assets pointing to the training and test data in the pre-existing storage account;
    * create a "sharing" storage account to safely communicate model weights between the silo and the orchestrator;
    * create a "sharing" datastore associated to the "sharing" storage account;
    * give the orchestrator's and silo's identities Write permissions to the "sharing" storage account.
* The script does NOT give the silos' identities read access to the pre-existing storage account containing the highly sensitive silo data. I made this decision because in practice, I'm not sure whether the users will have the permissions to do that. They will likely need to reach out to someone for that one-off action.
* To successfully use the script, one must have _Contributor_ access to the subscription (for creating all the resources), and _Owner_ access to the workspace resource group (this is to allow for adjusting permission to the "sharing" storage accounts, which are all created under the workspace resource group).


## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
* First, adjust a few values in `setup_info.yml`:
  * use the SubscriptionID value for the "Vienna PM 2" subscription and use `thopo-vanilla-fl-2-rg` as a resource group (unless you already have Owner role in a subscription or resource group, in which case, you can use those).
  * feel free to change the silos' names, but _do not change the `storage_account` and `container` values  (since they must be pointing to some pre-existing storage); do not change the silos locations either (they are actually not used for the computes right now due to a bug with a CLI, but eventually this will be fixed and we will want to create the silos computes in the same regions as the pre-existing storage accounts).
* Start the docker image as explained [here](https://github.com/Azure-Samples/azure-ml-federated-learning/blob/main/mlops/internal_silos/README.md).
* If it hasn't been done already, run the `ProvisionVanillaSetup.ps1` script to provision a vanilla setup.
* Run the `SecureVanillaSetup.ps1 script`.
  * Unless you have Owner access to the workspace resource group, you won't be able to change the permissions for the "sharing" storage accounts. This is expected, and will be clearly documented in the soon-to-come doc PR. Meanwhile, just reach out to me and I will grant access.
* Reach out to me so I can give the silos computes access to the pre-existing storage accounts.  



## What to Check
* Check that the example job can be submitted (this will require modifying the output datastores for every component).
* Try to introduce a mistake by having silo _n_ read from/write to the datastore associated with silo _m_. The job should fail.

## Future work
* Provide documentation for this step. 
* Adjust example job to use the newly introduced datastores.

