### PR TITLE
Rename demo script to highlight insecure status

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,12 +1,12 @@
 # Run a Federated Learning Demo in 5 mins
 
-In this tutorial, you run your first Python script in the cloud with Azure Machine Learning. This tutorial is *part 1 of a three-part tutorial series*.
-
-This tutorial avoids the complexity of training a machine learning model. You will run a "Hello World" Python script in the cloud. You will learn how a control script is used to configure and create a run in Azure Machine Learning.
-
 In this tutorial, you will:
 * Provision a fully functional environment in your own Azure subscription
 * Run a sample federated learning pipeline in Azure ML
+
+:warning: **IMPORTANT** :warning: This setup is intended only for demo purpose.
+The data is still accessible by the a user of your subscription when opening the storage accounts,
+and data exfiltration is easy.
 
 ## Prerequisites
 
@@ -35,7 +35,7 @@ We will provision:
 2. Run the bicep deployment script:
 
     ```bash
-    az deployment sub create --template-file ./mlops/bicep/vanilla_demo_setup.bicep --location eastus --parameters demoBaseName="fldemo"
+    az deployment sub create --template-file ./mlops/bicep/open_sandbox_setup.bicep --location eastus --parameters demoBaseName="fldemo"
     ```
 
     > NOTE: if someone already provisioned a demo with the same name in your subscription, change `demoBaseName` parameter to a unique value.

--- a/mlops/bicep/open_sandbox_setup.bicep
+++ b/mlops/bicep/open_sandbox_setup.bicep
@@ -1,5 +1,8 @@
-// This BICEP script will fully provision a functional federated learning demo
-// based on simple internal silos secured with UAI.
+// This BICEP script will fully provision a functional federated learning sandbox
+// based on simple internal silos secured with only UAI.
+
+// IMPORTANT: This setup is intended only for demo purpose. The data is still accessible
+// by the users when opening the storage accounts, and data exfiltration is easy.
 
 // For a given set of regions, it will provision:
 // - an AzureML workspace and compute cluster for orchestration


### PR DESCRIPTION
The demo provisioning is definitely not a production setup, and we need to highlight that both in the doc and in the script name.