### PR TITLE
add demoBaseName to guid name of role deployment

### DIFF
--- a/mlops/bicep/open_sandbox_setup.bicep
+++ b/mlops/bicep/open_sandbox_setup.bicep
@@ -49,7 +49,7 @@ param tags object = {
 }
 
 module storageReadWriteRoleDeployment './modules/roles/role_storage_read_write.bicep' = {
-  name: guid(subscription().subscriptionId, 'role_storage_read_write')
+  name: guid(subscription().subscriptionId, 'role_storage_read_write', demoBaseName)
   scope: subscription()
 }
 


### PR DESCRIPTION
Adding the "demoBaseName" to the function generating the name of role deployment. Haven't been able to test the entire script (since I'm only an Owner in the one RG), but the "Deployment already exists" issue seems gone.

Closes #77