### PR TITLE
Align HelloWorld example with "iteration" naming convention

### DIFF
--- a/examples/components/HELLOWORLD/traininsilo/run.py
+++ b/examples/components/HELLOWORLD/traininsilo/run.py
@@ -30,7 +30,7 @@ def get_arg_parser(parser=None):
     parser.add_argument(
         "--metrics_prefix", type=str, required=False, help="Metrics prefix"
     )
-    parser.add_argument("--round", type=str, required=False, help="Iteration name")
+    parser.add_argument("--iteration_name", type=str, required=False, help="Iteration name")
 
     parser.add_argument(
         "--lr", type=float, required=False, help="Training algorithm's learning rate"

--- a/examples/components/HELLOWORLD/traininsilo/traininsilo.yaml
+++ b/examples/components/HELLOWORLD/traininsilo/traininsilo.yaml
@@ -19,10 +19,10 @@ inputs:
     description: Metrics prefix
     default: Default-prefix
     optional: true
-  round:
+  iteration_name:
     type: string
     description: Iteration name
-    default: Default-round
+    default: Default-iteration
     optional: true
   checkpoint:
     type: uri_folder
@@ -35,7 +35,7 @@ inputs:
     optional: true
   epochs:
     type: integer
-    description: total number of local training rounds
+    description: total number of epochs for local training
     default: 3
     optional: true
   batch_size:
@@ -52,6 +52,6 @@ outputs:
 code: .
 
 command: >-
-  python run.py --train_data ${{inputs.train_data}} --test_data ${{inputs.test_data}} $[[--metrics_prefix ${{inputs.metrics_prefix}}]] $[[--round ${{inputs.round}}]] $[[--checkpoint ${{inputs.checkpoint}}]] --model ${{outputs.model}} $[[--lr ${{inputs.lr}}]] $[[--epochs ${{inputs.epochs}}]] $[[--batch_size ${{inputs.batch_size}}]]
+  python run.py --train_data ${{inputs.train_data}} --test_data ${{inputs.test_data}} $[[--metrics_prefix ${{inputs.metrics_prefix}}]] $[[--iteration_name ${{inputs.iteration_name}}]] $[[--checkpoint ${{inputs.checkpoint}}]] --model ${{outputs.model}} $[[--lr ${{inputs.lr}}]] $[[--epochs ${{inputs.epochs}}]] $[[--batch_size ${{inputs.batch_size}}]]
 
 environment: azureml:AzureML-sklearn-1.0-ubuntu20.04-py38-cpu:30


### PR DESCRIPTION
In previous PR #82 the name "round" was replaced by "iteration", except in the helloworld example. This PR fixes that.