### PR TITLE
Align round/iteration terminology with the native code

### DIFF
--- a/examples/components/HELLOWORLD/traininsilo/run.py
+++ b/examples/components/HELLOWORLD/traininsilo/run.py
@@ -41,7 +41,7 @@ def get_arg_parser(parser=None):
         "--epochs",
         type=int,
         required=False,
-        help="Total number of rounds for local training",
+        help="Total number of iterations for local training",
     )
     parser.add_argument("--batch_size", type=int, required=False, help="Batch Size")
     return parser

--- a/examples/pipelines/fl_cross_silo_factory/config.yaml
+++ b/examples/pipelines/fl_cross_silo_factory/config.yaml
@@ -49,7 +49,7 @@ federated_learning:
 
 # training parameters
 training_parameters:
-  num_of_iterations: 2
+  num_rounds: 2
   epochs: 3
   lr: 0.01
   batch_size: 64

--- a/examples/pipelines/fl_cross_silo_factory/config.yaml
+++ b/examples/pipelines/fl_cross_silo_factory/config.yaml
@@ -49,7 +49,7 @@ federated_learning:
 
 # training parameters
 training_parameters:
-  num_rounds: 2
+  num_of_iterations: 2
   epochs: 3
   lr: 0.01
   batch_size: 64

--- a/examples/pipelines/fl_cross_silo_factory/fl_factory.py
+++ b/examples/pipelines/fl_cross_silo_factory/fl_factory.py
@@ -65,7 +65,7 @@ class FederatedLearningPipelineFactory:
         )
 
     def custom_fl_data_output(
-        self, datastore_name, output_name, unique_id="${{name}}", round=None
+        self, datastore_name, output_name, unique_id="${{name}}", iteration_num=None
     ):
         """Returns an Output pointing to a path to store the data during FL training.
 
@@ -73,14 +73,14 @@ class FederatedLearningPipelineFactory:
             datastore_name (str): name of the Azure ML datastore
             output_name (str): a name unique to this output
             unique_id (str): a unique id for the run (default: inject run id with ${{name}})
-            round (str): an round id if relevant
+            iteration_num (str): an iteration number if relevant
 
         Returns:
             data_path (str): direct url to the data path to store the data
         """
         data_path = f"azureml://datastores/{datastore_name}/paths/federated_learning/{output_name}/{unique_id}/"
-        if round:
-            data_path += f"round_{round}/"
+        if iteration_num:
+            data_path += f"iteration_{iteration_num}/"
 
         return Output(type=AssetTypes.URI_FOLDER, mode="mount", path=data_path)
 
@@ -202,10 +202,10 @@ class FederatedLearningPipelineFactory:
             ### TRAINING ###
             ################
 
-            running_outputs = {}  # for round 1, we have no pre-existing checkpoint
+            running_outputs = {}  # for iteration 1, we have no pre-existing checkpoint
 
-            # now for each round, run training
-            for round in range(1, iterations + 1):
+            # now for each iteration, run training
+            for iteration in range(1, iterations + 1):
                 # collect all outputs in a dict to be used for aggregation
                 silo_training_outputs = []
 
@@ -301,7 +301,7 @@ class FederatedLearningPipelineFactory:
                     model_output_datastore=self.orchestrator["datastore"],
                 )
 
-                # let's keep track of the running outputs (dict) to be used as input for next round
+                # let's keep track of the running outputs (dict) to be used as input for next iteration
                 running_outputs = aggregation_outputs
 
             return running_outputs

--- a/examples/pipelines/fl_cross_silo_factory/submit.py
+++ b/examples/pipelines/fl_cross_silo_factory/submit.py
@@ -200,7 +200,7 @@ def silo_training(
         train_data=train_data,
         # with the test_data from the pre_processing step
         test_data=test_data,
-        # and the checkpoint from previous round (or None if round == 1)
+        # and the checkpoint from previous iteration (or None if iteration == 1)
         checkpoint=running_checkpoint,
         # Learning rate for local training
         lr=lr,

--- a/examples/pipelines/fl_cross_silo_factory/submit.py
+++ b/examples/pipelines/fl_cross_silo_factory/submit.py
@@ -292,7 +292,7 @@ pipeline_job = builder.build_basic_fl_pipeline(
     silo_training,
     orchestrator_aggregation,
     # RESERVED: this kwarg is for building iterations
-    iterations=YAML_CONFIG.training_parameters.num_rounds,
+    iterations=YAML_CONFIG.training_parameters.num_of_iterations,
     # any additional custom kwarg will be sent to silo_training() as is
     lr=YAML_CONFIG.training_parameters.lr,
     batch_size=YAML_CONFIG.training_parameters.batch_size,


### PR DESCRIPTION
This PR fixes a minor issue in the factory job part of the repo, where the code is expecting a parameter named `num_rounds` while the config only provides `num_of_iterations`.

The issue is solved by replacing "round" by "iteration" throughout, as was done in #82. 

Successfully submitted job can be found [here](https://ml.azure.com/experiments/id/e93bbfdd-10b9-4d32-bfee-0af4af637dff/runs/quiet_lizard_xq7qfg7pwh?wsid=/subscriptions/48bbc269-ce89-4f6f-9a12-c6f91fcb772d/resourceGroups/thopo-owner-fldev-rg/providers/Microsoft.MachineLearningServices/workspaces/aml-thopofl8&tid=72f988bf-86f1-41af-91ab-2d7cd011db47#) and was submitted by running:
```bash
python .\examples\pipelines\fl_cross_silo_factory\submit.py --submit --ignore_validation
```
(which did not work before).