### PR TITLE
Implement option to turn orchestrator storage fully private (behind PLE)

### DIFF
--- a/mlops/bicep/modules/azureml/open_azureml_workspace.bicep
+++ b/mlops/bicep/modules/azureml/open_azureml_workspace.bicep
@@ -8,8 +8,11 @@
 targetScope = 'resourceGroup'
 
 // required parameters
+@description('Base name to create all the resources')
+param baseName string
+
 @description('Machine learning workspace name')
-param machineLearningName string
+param machineLearningName string = 'aml-${baseName}'
 
 // optional parameters
 @description('Machine learning workspace display name')
@@ -28,16 +31,16 @@ param hbi_workspace bool = false
 param tags object = {}
 
 @description('Name of the application insights resource')
-param applicationInsightsName string = 'appi-${machineLearningName}'
+param applicationInsightsName string = 'appi-${baseName}'
 
 @description('Name of the container registry resource')
-param containerRegistryName string = replace('cr-${machineLearningName}','-','') // replace because only alphanumeric characters are supported
+param containerRegistryName string = replace('cr-${baseName}','-','') // replace because only alphanumeric characters are supported
 
 @description('Name of the key vault resource')
-param keyVaultName string = 'kv-${machineLearningName}'
+param keyVaultName string = 'kv-${baseName}'
 
 @description('Name of the storage account resource')
-param storageAccountName string = replace('st-${machineLearningName}','-','') // replace because only alphanumeric characters are supported
+param storageAccountName string = replace('st-${baseName}','-','') // replace because only alphanumeric characters are supported
 
 @description('Name of the default compute cluster in orchestrator')
 param defaultComputeName string = 'cpu-cluster'

--- a/mlops/bicep/modules/computes/vnet_new_aml_compute.bicep
+++ b/mlops/bicep/modules/computes/vnet_new_aml_compute.bicep
@@ -68,8 +68,12 @@ module vnet '../networking/vnet.bicep' = {
     virtualNetworkName: vnetResourceName
     networkSecurityGroupId: nsg.outputs.id
     vnetAddressPrefix: vnetAddressPrefix
-    subnetPrefix: subnetPrefix
-    subnetName: subnetName
+    subnets: [
+      {
+        name: subnetName
+        addressPrefix: subnetPrefix
+      }
+    ]
     tags: tags
   }
 }

--- a/mlops/bicep/modules/fl_pairs/vnet_compute_storage_pair.bicep
+++ b/mlops/bicep/modules/fl_pairs/vnet_compute_storage_pair.bicep
@@ -40,9 +40,6 @@ param identityType string = 'UserAssigned'
 @description('Name of the UAI for the pair compute cluster (if identityType==UserAssigned)')
 param uaiName string = 'uai-${pairBaseName}'
 
-@description('Name of the existing private DNS zone for storage in this resource group')
-param privateStorageDnsZoneName string = 'privatelink.blob.${environment().suffixes.storage}'
-
 @description('Name of the Network Security Group resource')
 param nsgResourceName string = 'nsg-${pairBaseName}'
 
@@ -54,6 +51,12 @@ param vnetAddressPrefix string = '10.0.0.0/16'
 
 @description('Subnet address prefix')
 param subnetPrefix string = '10.0.0.0/24'
+
+@description('Use a static ip for storage PLE')
+param useStorageStaticIP bool = false
+
+@description('Which static IP to use for storage PLE (if useStorageStaticIP is true)')
+param storagePLEStaticIP string = '10.0.0.50'
 
 @description('Subnet name')
 param subnetName string = 'snet-training'
@@ -70,6 +73,12 @@ param storagePublicNetworkAccess string = 'Disabled'
 
 @description('Allow compute cluster to access storage account with R/W permissions (using UAI)')
 param applyDefaultPermissions bool = true
+
+@description('Name of the private DNS zone for blob')
+param blobPrivateDNSZoneName string = 'privatelink.blob.${environment().suffixes.storage}'
+
+@description('Location of the private DNS zone for blob')
+param blobPrivateDNSZoneLocation string = 'global'
 
 @description('Tags to curate the resources in Azure.')
 param tags object = {}
@@ -123,28 +132,23 @@ module storageDeployment '../storages/new_blob_storage_datastore.bicep' = {
   }
 }
 
-// Look for existing private DNS zone for all our private endpoints
-resource privateStorageDnsZone 'Microsoft.Network/privateDnsZones@2020-06-01' existing = {
-  name: privateStorageDnsZoneName
-}
-
 // Create a private service endpoints internal to each pair for their respective storages
 module pairStoragePrivateEndpoint '../networking/private_endpoint.bicep' = if (storagePublicNetworkAccess == 'Disabled') {
-  name: '${pairBaseName}-endpoint-to-instorage'
+  name: '${pairBaseName}-endpoint-to-insilo-storage'
   scope: resourceGroup()
   params: {
     location: pairRegion
     tags: tags
-    privateLinkServiceId: storageDeployment.outputs.storageId
-    storagePleRootName: 'ple-${storageDeployment.outputs.storageName}-to-${pairBaseName}-st-blob'
-    subnetId: '${computeDeployment.outputs.vnetId}/subnets/${computeDeployment.outputs.subnetName}'
+    resourceServiceId: storageDeployment.outputs.storageId
+    resourceName: storageDeployment.outputs.storageName
+    pleRootName: 'ple-${storageDeployment.outputs.storageName}-to-${pairBaseName}-st-blob'
     virtualNetworkId: computeDeployment.outputs.vnetId
-    privateDNSZoneName: privateStorageDnsZone.name
-    privateDNSZoneId: privateStorageDnsZone.id
-    groupIds: [
-      'blob'
-      //'file'
-    ]
+    subnetId: '${computeDeployment.outputs.vnetId}/subnets/${computeDeployment.outputs.subnetName}'
+    useStaticIPAddress: useStorageStaticIP
+    privateIPAddress: storagePLEStaticIP
+    privateDNSZoneName: blobPrivateDNSZoneName
+    privateDNSZoneLocation: blobPrivateDNSZoneLocation
+    groupId: 'blob'
   }
   dependsOn: [
     storageDeployment

--- a/mlops/bicep/modules/storages/new_blob_storage_datastore.bicep
+++ b/mlops/bicep/modules/storages/new_blob_storage_datastore.bicep
@@ -5,14 +5,24 @@ param machineLearningName string
 @description('The region of the machine learning workspace')
 param machineLearningRegion string = resourceGroup().location
 
-@description('Tags to add to the resources')
-param tags object
-
 @description('Name of the storage account')
 param storageName string
 
 @description('Azure region of the storage to create')
 param storageRegion string
+
+@allowed([
+  'Standard_LRS'
+  'Standard_ZRS'
+  'Standard_GRS'
+  'Standard_GZRS'
+  'Standard_RAGRS'
+  'Standard_RAGZRS'
+  'Premium_LRS'
+  'Premium_ZRS'
+])
+@description('Storage SKU')
+param storageSKU string = 'Standard_LRS'
 
 @description('Name of the storage container resource to create for the pair')
 param containerName string = 'private'
@@ -27,19 +37,8 @@ param subnetIds array = []
 @description('Allow or disallow public network access to Storage Account.')
 param publicNetworkAccess string = 'Disabled' // for Disabled, you'd need to create private endpoints
 
-@allowed([
-  'Standard_LRS'
-  'Standard_ZRS'
-  'Standard_GRS'
-  'Standard_GZRS'
-  'Standard_RAGRS'
-  'Standard_RAGZRS'
-  'Premium_LRS'
-  'Premium_ZRS'
-])
-
-@description('Storage SKU')
-param storageSKU string = 'Standard_LRS'
+@description('Tags to add to the resources')
+param tags object = {}
 
 var storageNameCleaned = replace(storageName, '-', '')
 var storageAccountCleanName = substring(storageNameCleaned, 0, min(length(storageNameCleaned),24))

--- a/mlops/bicep/open_sandbox_setup.bicep
+++ b/mlops/bicep/open_sandbox_setup.bicep
@@ -62,6 +62,7 @@ module workspace './modules/azureml/open_azureml_workspace.bicep' = {
   name: '${demoBaseName}-aml-${orchestratorRegion}'
   scope: resourceGroup()
   params: {
+    baseName: demoBaseName
     machineLearningName: 'aml-${demoBaseName}'
     location: orchestratorRegion
     tags: tags

--- a/mlops/bicep/vnet_publicip_sandbox_setup.bicep
+++ b/mlops/bicep/vnet_publicip_sandbox_setup.bicep
@@ -40,6 +40,13 @@ param identityType string = 'UserAssigned'
 @description('Region of the orchestrator (workspace, central storage and compute).')
 param orchestratorRegion string = resourceGroup().location
 
+@description('Set the orchestrator storage as private, with endpoints into each silo.')
+@allowed([
+  'public'
+  'private'
+])
+param orchestratorAccess string = 'public'
+
 @description('List of each region in which to create an internal silo.')
 param siloRegions array = [
   'westus'
@@ -69,18 +76,25 @@ module workspace './modules/azureml/open_azureml_workspace.bicep' = {
   scope: resourceGroup()
   params: {
     machineLearningName: 'aml-${demoBaseName}'
+    baseName: substring(uniqueString(resourceGroup().id, demoBaseName), 0, 4)
     location: orchestratorRegion
     tags: tags
   }
 }
 
+// Requirement: create all required private DNS zones before creating the orchestrator+silos
 resource storagePrivateDnsZone 'Microsoft.Network/privateDnsZones@2020-06-01' = {
   name: 'privatelink.blob.${environment().suffixes.storage}'
   location: 'global'
 }
 
+
+// In order to be able to record this storage in dns zone with static ip
+// we need to set this storage account name ourselves here
+var orchestratorStorageAccountName = replace('st${demoBaseName}orch','-','')
+var orchestratorStorageAccountCleanName = substring(orchestratorStorageAccountName, 0, min(length(orchestratorStorageAccountName),24))
+
 // Create an orchestrator compute+storage pair and attach to workspace
-// This pair will be considered eyes-on
 module orchestrator './modules/fl_pairs/vnet_compute_storage_pair.bicep' = {
   name: '${demoBaseName}-vnetpair-orchestrator'
   scope: resourceGroup()
@@ -96,6 +110,8 @@ module orchestrator './modules/fl_pairs/vnet_compute_storage_pair.bicep' = {
     computeName: 'cpu-orchestrator' // let's not use demo base name in cluster name
     computeSKU: computeSKU
     computeNodes: 4
+
+    storageAccountName: orchestratorStorageAccountCleanName
     datastoreName: 'datastore_orchestrator' // let's not use demo base name
 
     // identity for permissions model
@@ -108,19 +124,29 @@ module orchestrator './modules/fl_pairs/vnet_compute_storage_pair.bicep' = {
     vnetAddressPrefix: '10.0.0.0/24'
     subnetPrefix: '10.0.0.0/24'
 
+    // NOTE: when using storagePublicNetworkAccess = 'Disabled' we will need to
+    // have multiple endpoints from the orchestrator storage
+    // (to orch vnet and to each silo vnet)
+    // we need to set static IP to create a unique record in DNS zone
+    // with all the IPs to the orchestrator storage
+    useStorageStaticIP: orchestratorAccess == 'Disabled'
+    storagePLEStaticIP: '10.0.0.50'
+
     // IMPORTANT: compute still has public ip to let workspace submit job
     // traffic regulated by NSG
     enableNodePublicIp: true
 
     // IMPORTANT: below means all traffic allowed (with permissions via UAI)
     // alternative is vNetOnly for specific vnets, or Disabled for service endpoints
-    storagePublicNetworkAccess: 'Enabled'
+    storagePublicNetworkAccess: orchestratorAccess == 'public' ? 'Enabled' : 'Disabled'
 
     //allowedSubnetIds: [for i in range(0, siloCount): silos[i].outputs.subnetId]
+
+    blobPrivateDNSZoneName: storagePrivateDnsZone.name
+    blobPrivateDNSZoneLocation: storagePrivateDnsZone.location
   }
   dependsOn: [
     workspace
-    storagePrivateDnsZone
   ]
 }
 
@@ -160,13 +186,60 @@ module silos './modules/fl_pairs/vnet_compute_storage_pair.bicep' = [for i in ra
 
     // IMPORTANT: below Disabled means data will be only accessible via private service endpoints
     storagePublicNetworkAccess: 'Disabled'
+
+    blobPrivateDNSZoneName: storagePrivateDnsZone.name
+    blobPrivateDNSZoneLocation: storagePrivateDnsZone.location
   }
   dependsOn: [
     workspace
-    storagePrivateDnsZone
   ]
 }]
 
+// Attach orchestrator and silos together with private endpoints and RBAC
+// Create a private service endpoints internal to each pair for their respective storages
+module orchToSiloPrivateEndpoints './modules/networking/private_endpoint.bicep' = [for i in range(0, siloCount): if (orchestratorAccess == 'private') {
+  name: '${demoBaseName}-orch-to-silo${i}-endpoint'
+  scope: resourceGroup()
+  params: {
+    location: silos[i].outputs.region
+    tags: tags
+    resourceServiceId: orchestrator.outputs.storageServiceId
+    resourceName: orchestrator.outputs.storageName
+    linkVirtualNetwork: false // the link already exists at this point
+    pleRootName: 'ple-${orchestrator.outputs.storageName}-to-${demoBaseName}-silo${i}-st-blob'
+    virtualNetworkId: silos[i].outputs.vnetId
+    subnetId: silos[i].outputs.subnetId
+    // we need to set static IP to create a unique record in DNS zone
+    // with all the IPs to the orchestrator storage
+    useStaticIPAddress: true
+    privateIPAddress: '10.0.${i+1}.50'
+    privateDNSZoneName: storagePrivateDnsZone.name
+    privateDNSZoneLocation: storagePrivateDnsZone.location
+    groupId: 'blob'
+  }
+  dependsOn: [
+    orchestrator
+    silos[i]
+  ]
+}]
+
+// NOTE: when creating multiple endpoints in multiple vnets using the same private DNS zone
+// the IP address of each endpoint will overwrite the previous one.
+// we are using static IP adresses so that we can create a unique record in the DNS zone
+// with all the IP adresses from each vnet (orch + silos)
+resource privateDnsARecordOrchestratorStorage 'Microsoft.Network/privateDnsZones/A@2020-06-01' = if (orchestratorAccess == 'private') {
+  name: orchestratorStorageAccountCleanName
+  parent: storagePrivateDnsZone
+  properties: {
+    ttl: 3600
+    aRecords: [ for i in range(0, siloCount+1): {
+        ipv4Address: '10.0.${i}.50'
+    }]
+  }
+  dependsOn: [
+    orchToSiloPrivateEndpoints
+  ]
+}
 
 // Set R/W permissions for silo identity towards (eyes-on) orchestrator storage
 module siloToOrchPermissions './modules/permissions/msi_storage_rw.bicep' = [for i in range(0, siloCount): {


### PR DESCRIPTION
## Purpose

This PR implements multiple changes to the code to allow for orchestrator storage to be fully private. In order to support this, changes are:
* add option in the publicip sandbox bicep
* reuse single private endpoint code accross all provisioning scripts
* enforce static IP address for orchestrator and silo endpoints
* make all private DNS zone names customizable
* set A record with all IP adresses in private DNS zone

NOTE: when creating multiple endpoints in multiple vnets using the same private DNS zone, the IP address of each endpoint will overwrite the previous one. In this PR we are using static IP adresses so that we can create a unique record in the DNS zone with all the IP adresses from each vnet (orch + silos).

## Does this introduce a breaking change?

Not from the user experience perspective.

```
[ ] Yes
[x] No
```

## Pull Request Type

```
[ ] Bugfix
[x] Feature
[x] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```
