### PR TITLE
Implement generic FedAvg without model object

### DIFF
--- a/examples/components/MNIST/aggregatemodelweights/aggregatemodelweights.yaml
+++ b/examples/components/MNIST/aggregatemodelweights/aggregatemodelweights.yaml
@@ -45,4 +45,6 @@ command: >-
   $[[${{inputs.input_silo_4}}]] 
   $[[${{inputs.input_silo_5}}]] 
 
-environment: azureml:AzureML-pytorch-1.10-ubuntu18.04-py38-cuda11-gpu:33
+environment:
+  conda_file: ./conda.yaml
+  image: mcr.microsoft.com/azureml/openmpi3.1.2-ubuntu18.04

--- a/examples/components/MNIST/aggregatemodelweights/aggregatemodelweights.yaml
+++ b/examples/components/MNIST/aggregatemodelweights/aggregatemodelweights.yaml
@@ -20,6 +20,14 @@ inputs:
     type: uri_folder
     description: input from silo 3 (e.g., model weights, or gradient updates)
     optional: true
+  input_silo_4:
+    type: uri_folder
+    description: input from silo 4 (e.g., model weights, or gradient updates)
+    optional: true
+  input_silo_5:
+    type: uri_folder
+    description: input from silo 5 (e.g., model weights, or gradient updates)
+    optional: true
 
 outputs:
   aggregated_output:
@@ -29,11 +37,12 @@ outputs:
 code: .
 
 command: >-
-  python run.py --aggregated_output ${{outputs.aggregated_output}}
-  --input_silo_1 ${{inputs.input_silo_1}}
-  $[[--input_silo_2 ${{inputs.input_silo_2}}]]
-  $[[--input_silo_3 ${{inputs.input_silo_3}}]]
+  python run.py --output ${{outputs.aggregated_output}} 
+  --extension pt 
+  --checkpoints ${{inputs.input_silo_1}} 
+  $[[${{inputs.input_silo_2}}]] 
+  $[[${{inputs.input_silo_3}}]] 
+  $[[${{inputs.input_silo_4}}]] 
+  $[[${{inputs.input_silo_5}}]] 
 
-environment: 
-  conda_file: ./conda.yaml
-  image: mcr.microsoft.com/azureml/openmpi3.1.2-ubuntu18.04
+environment: azureml:AzureML-pytorch-1.10-ubuntu18.04-py38-cuda11-gpu:33

--- a/examples/components/MNIST/aggregatemodelweights/run.py
+++ b/examples/components/MNIST/aggregatemodelweights/run.py
@@ -40,7 +40,7 @@ def get_arg_parser(parser=None):
     return parser
 
 
-class PyTorchStadeDictFedAvg:
+class PyTorchStateDictFedAvg:
     """Class to handle FedAvg of pytorch models."""
 
     def __init__(self):
@@ -154,7 +154,7 @@ def main(cli_args=None):
         else:
             model_paths.append(model_path)
 
-    model_handler = PyTorchStadeDictFedAvg()
+    model_handler = PyTorchStateDictFedAvg()
     for model_path in model_paths:
         model_handler.add_model(model_path)
 

--- a/examples/components/MNIST/aggregatemodelweights/run.py
+++ b/examples/components/MNIST/aggregatemodelweights/run.py
@@ -86,8 +86,11 @@ class PyTorchStadeDictFedAvg:
             del add_model
 
     def save_model(self, model_path: str):
-        torch.save(self.avg_state_dict, model_path)
-
+        if self.model_class == "OrderedDict":
+            torch.save(self.avg_state_dict, model_path)
+        else:
+            self.model_object.load_state_dict(self.avg_state_dict)
+            torch.save(self.model_object, model_path)
 
 
 def main(cli_args=None):

--- a/examples/components/MNIST/aggregatemodelweights/run.py
+++ b/examples/components/MNIST/aggregatemodelweights/run.py
@@ -25,15 +25,24 @@ def get_arg_parser(parser=None):
     if parser is None:
         parser = argparse.ArgumentParser(description=__doc__)
 
-    parser.add_argument("--checkpoints", type=str, required=True, nargs="+", help="list of paths or directories to search for model files")
+    parser.add_argument(
+        "--checkpoints",
+        type=str,
+        required=True,
+        nargs="+",
+        help="list of paths or directories to search for model files",
+    )
     parser.add_argument("--extension", type=str, default="pt", help="model extension")
-    parser.add_argument("--output", type=str, required=True, help="where to write the averaged model")
+    parser.add_argument(
+        "--output", type=str, required=True, help="where to write the averaged model"
+    )
 
     return parser
 
 
 class PyTorchStadeDictFedAvg:
     """Class to handle FedAvg of pytorch models."""
+
     def __init__(self):
         """Constructor."""
         # below we keep the average of the models
@@ -66,13 +75,17 @@ class PyTorchStadeDictFedAvg:
 
             self.ref_keys = set(self.avg_state_dict.keys())
 
-            self.logger.info(f"Loaded model from path={model_path}, class={self.model_class}, keys={self.ref_keys}")
+            self.logger.info(
+                f"Loaded model from path={model_path}, class={self.model_class}, keys={self.ref_keys}"
+            )
             self.model_count = 1
 
         else:
             # load the new model
             add_model = torch.load(model_path)
-            assert add_model.__class__.__name__ == self.model_class, f"Model class mismatch: {add_model.__class__.__name__} != {self.model_class}"
+            assert (
+                add_model.__class__.__name__ == self.model_class
+            ), f"Model class mismatch: {add_model.__class__.__name__} != {self.model_class}"
 
             if self.model_class != "OrderedDict":
                 # if the model loaded is actually a class, we need to extract the state_dict
@@ -84,7 +97,9 @@ class PyTorchStadeDictFedAvg:
                 self.ref_keys == add_model_keys
             ), f"model has keys {add_model_keys} != first model keys {self.ref_keys}"
 
-            self.logger.info(f"Loaded model from path={model_path}, class={self.model_class}, keys=IDEM")
+            self.logger.info(
+                f"Loaded model from path={model_path}, class={self.model_class}, keys=IDEM"
+            )
 
             # rolling average
             for key in self.ref_keys:
@@ -132,7 +147,9 @@ def main(cli_args=None):
     model_paths = []
     for model_path in args.checkpoints:
         if os.path.isdir(model_path):
-            for f in glob.glob(os.path.join(model_path, f"*.{args.extension}"), recursive=True):
+            for f in glob.glob(
+                os.path.join(model_path, f"*.{args.extension}"), recursive=True
+            ):
                 model_paths.append(f)
         else:
             model_paths.append(model_path)
@@ -142,6 +159,7 @@ def main(cli_args=None):
         model_handler.add_model(model_path)
 
     model_handler.save_model(os.path.join(args.output, f"model.{args.extension}"))
+
 
 if __name__ == "__main__":
     # Set logging to sys.out

--- a/examples/components/MNIST/aggregatemodelweights/run.py
+++ b/examples/components/MNIST/aggregatemodelweights/run.py
@@ -82,20 +82,20 @@ class PyTorchStateDictFedAvg:
 
         else:
             # load the new model
-            add_model = torch.load(model_path)
+            model_to_add = torch.load(model_path)
             assert (
-                add_model.__class__.__name__ == self.model_class
-            ), f"Model class mismatch: {add_model.__class__.__name__} != {self.model_class}"
+                model_to_add.__class__.__name__ == self.model_class
+            ), f"Model class mismatch: {model_to_add.__class__.__name__} != {self.model_class}"
 
             if self.model_class != "OrderedDict":
                 # if the model loaded is actually a class, we need to extract the state_dict
-                model_object = add_model
-                add_model = model_object.state_dict()
+                model_object = model_to_add
+                model_to_add = model_object.state_dict()
 
-            add_model_keys = set(add_model.keys())
+            model_to_add_keys = set(model_to_add.keys())
             assert (
-                self.ref_keys == add_model_keys
-            ), f"model has keys {add_model_keys} != first model keys {self.ref_keys}"
+                self.ref_keys == model_to_add_keys
+            ), f"model has keys {model_to_add_keys} != first model keys {self.ref_keys}"
 
             self.logger.info(
                 f"Loaded model from path={model_path}, class={self.model_class}, keys=IDEM"
@@ -104,14 +104,14 @@ class PyTorchStateDictFedAvg:
             # rolling average
             for key in self.ref_keys:
                 self.avg_state_dict[key] = torch.div(
-                    self.avg_state_dict[key] * self.model_count + add_model[key],
+                    self.avg_state_dict[key] * self.model_count + model_to_add[key],
                     float(self.model_count + 1),
                 )
 
             self.model_count += 1
 
             # would this help free memory?
-            del add_model
+            del model_to_add
 
     def save_model(self, model_path: str):
         """Save the averaged model.


### PR DESCRIPTION
## Purpose

This PR recodes the aggregateweights example from MNIST to aggregate any state dict without having to know the model itself.

This makes the fedavg implement generic enough to be used for potentially any pytorch model in the other worksloads we're developing.

It also implements the averaging model by model, requiring less memory.

## Does this introduce a breaking change?

```
[ ] Yes
[x] No
```

## Pull Request Type

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What to Check

* run this in an FL experiment to see if there's no impact on model quality (sanity check)
