### PR TITLE
Hotfix instructions for --cluster-type parameter when creating an external silo

### DIFF
--- a/docs/provisioning/external-silos.md
+++ b/docs/provisioning/external-silos.md
@@ -93,8 +93,6 @@ az k8s-extension create --name <extension-name> --extension-type Microsoft.Azure
 ```
 where `<extension-name>` can be chosen arbitrarily.
 
-> Note: if you're using an AKS cluster (as opposed to a local k8s cluster), you'll need to change the `--cluster-type` parameter value from `connectedClusters` to `managedClusters`.
-
 The deployment can be verified by the following.
 ```bash
 az k8s-extension show --name <extension-name> --cluster-type connectedClusters --cluster-name <Azure-Arc-enabled-k8s-resource-name> --resource-group <connected-cluster-resource-group>


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
One of our customers was having issues setting up their external silo with AKS. I thought it was because for the AKS case (as opposed to on-prem k8s), the `--cluster-type` parameter in the command to deploy the Azure ML extension should take the value `managedClusters`. I was wrong. This value is for connecting an AKS directly to Azure ML, without going through Arc. This PR reverts the doc hotfix change I made back then.

(BTW, customer got unblocked by using a different k8s version in their AKS.)

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:
```
