### PR TITLE
Rename the attached "keyvault" in our sandboxes to "workspace secret store" to avoid confusion

### DIFF
--- a/.github/actions/bicep-to-arm-template-diff/action.yaml
+++ b/.github/actions/bicep-to-arm-template-diff/action.yaml
@@ -14,6 +14,7 @@ runs:
     - name: Build bicep into arm
       shell: bash
       run: |
+        az config set bicep.use_binary_from_path=False
         az bicep install --version v0.14.85
         az bicep build --file ${{ inputs.source-file-path }} --stdout | jq -S . > source.json
 

--- a/.github/actions/open-provision-resources/action.yaml
+++ b/.github/actions/open-provision-resources/action.yaml
@@ -68,6 +68,6 @@ runs:
     - name: Set kaggle credentials in the Azure key vault
       shell: bash
       run: |
-        az keyvault set-policy -n ws-secrets-${{ inputs.demo-base-name }} --secret-permissions list set delete --object-id ${{ inputs.github-sp-object-id }}
-        az keyvault secret set --name kaggleusername --vault-name ws-secrets-${{ inputs.demo-base-name }} --value ${{ inputs.kaggle-username }}
-        az keyvault secret set --name kagglekey --vault-name ws-secrets-${{ inputs.demo-base-name }} --value ${{ inputs.kaggle-api-token }}
+        az keyvault set-policy -n ws-shkv-${{ inputs.demo-base-name }} --secret-permissions list set delete --object-id ${{ inputs.github-sp-object-id }}
+        az keyvault secret set --name kaggleusername --vault-name ws-shkv-${{ inputs.demo-base-name }} --value ${{ inputs.kaggle-username }}
+        az keyvault secret set --name kagglekey --vault-name ws-shkv-${{ inputs.demo-base-name }} --value ${{ inputs.kaggle-api-token }}

--- a/.github/actions/open-provision-resources/action.yaml
+++ b/.github/actions/open-provision-resources/action.yaml
@@ -68,6 +68,6 @@ runs:
     - name: Set kaggle credentials in the Azure key vault
       shell: bash
       run: |
-        az keyvault set-policy -n kv-${{ inputs.demo-base-name }} --secret-permissions list set delete --object-id ${{ inputs.github-sp-object-id }}
-        az keyvault secret set --name kaggleusername --vault-name kv-${{ inputs.demo-base-name }} --value ${{ inputs.kaggle-username }}
-        az keyvault secret set --name kagglekey --vault-name kv-${{ inputs.demo-base-name }} --value ${{ inputs.kaggle-api-token }}
+        az keyvault set-policy -n ws-secrets-${{ inputs.demo-base-name }} --secret-permissions list set delete --object-id ${{ inputs.github-sp-object-id }}
+        az keyvault secret set --name kaggleusername --vault-name ws-secrets-${{ inputs.demo-base-name }} --value ${{ inputs.kaggle-username }}
+        az keyvault secret set --name kagglekey --vault-name ws-secrets-${{ inputs.demo-base-name }} --value ${{ inputs.kaggle-api-token }}

--- a/.github/actions/vnet-provision-resources/action.yaml
+++ b/.github/actions/vnet-provision-resources/action.yaml
@@ -68,6 +68,6 @@ runs:
     - name: Set kaggle credentials in the Azure key vault
       shell: bash
       run: |
-        az keyvault set-policy -n ws-secrets-${{ inputs.demo-base-name }} --secret-permissions list set delete --object-id ${{ inputs.github-sp-object-id }}
-        az keyvault secret set --name kaggleusername --vault-name ws-secrets-${{ inputs.demo-base-name }} --value ${{ inputs.kaggle-username }}
-        az keyvault secret set --name kagglekey --vault-name ws-secrets-${{ inputs.demo-base-name }} --value ${{ inputs.kaggle-api-token }}
+        az keyvault set-policy -n ws-shkv-${{ inputs.demo-base-name }} --secret-permissions list set delete --object-id ${{ inputs.github-sp-object-id }}
+        az keyvault secret set --name kaggleusername --vault-name ws-shkv-${{ inputs.demo-base-name }} --value ${{ inputs.kaggle-username }}
+        az keyvault secret set --name kagglekey --vault-name ws-shkv-${{ inputs.demo-base-name }} --value ${{ inputs.kaggle-api-token }}

--- a/.github/actions/vnet-provision-resources/action.yaml
+++ b/.github/actions/vnet-provision-resources/action.yaml
@@ -68,6 +68,6 @@ runs:
     - name: Set kaggle credentials in the Azure key vault
       shell: bash
       run: |
-        az keyvault set-policy -n kv-${{ inputs.demo-base-name }} --secret-permissions list set delete --object-id ${{ inputs.github-sp-object-id }}
-        az keyvault secret set --name kaggleusername --vault-name kv-${{ inputs.demo-base-name }} --value ${{ inputs.kaggle-username }}
-        az keyvault secret set --name kagglekey --vault-name kv-${{ inputs.demo-base-name }} --value ${{ inputs.kaggle-api-token }}
+        az keyvault set-policy -n ws-secrets-${{ inputs.demo-base-name }} --secret-permissions list set delete --object-id ${{ inputs.github-sp-object-id }}
+        az keyvault secret set --name kaggleusername --vault-name ws-secrets-${{ inputs.demo-base-name }} --value ${{ inputs.kaggle-username }}
+        az keyvault secret set --name kagglekey --vault-name ws-secrets-${{ inputs.demo-base-name }} --value ${{ inputs.kaggle-api-token }}

--- a/docs/real-world-examples/ccfraud.md
+++ b/docs/real-world-examples/ccfraud.md
@@ -45,7 +45,7 @@ Kaggle requires a username and an [API key](https://github.com/Kaggle/kaggle-api
     az keyvault set-policy -n <key-vault-name> --secret-permissions list set delete --object-id <object-id>
     ```
 
-    > Note: The AML workspace you created with the aforementioned script contains the name of the key vault. Default is `ws-secrets-fldemo`.
+    > Note: The AML workspace you created with the aforementioned script contains the name of the key vault. Default is `ws-shkv-fldemo`.
 
 3. With your newly created permissions, you can now create a secret to store the `kaggleusername`.
 

--- a/docs/real-world-examples/ccfraud.md
+++ b/docs/real-world-examples/ccfraud.md
@@ -45,7 +45,7 @@ Kaggle requires a username and an [API key](https://github.com/Kaggle/kaggle-api
     az keyvault set-policy -n <key-vault-name> --secret-permissions list set delete --object-id <object-id>
     ```
 
-    > Note: The AML workspace you created with the aforementioned script contains the name of the key vault. Default is `kv-fldemo`.
+    > Note: The AML workspace you created with the aforementioned script contains the name of the key vault. Default is `ws-secrets-fldemo`.
 
 3. With your newly created permissions, you can now create a secret to store the `kaggleusername`.
 

--- a/docs/real-world-examples/pneumonia.md
+++ b/docs/real-world-examples/pneumonia.md
@@ -46,7 +46,7 @@ Kaggle requires a username and an [API key](https://github.com/Kaggle/kaggle-api
     az keyvault set-policy -n <key-vault-name> --secret-permissions list set delete --object-id <object-id>
     ```
 
-    > Note: The AML workspace you created with the aforementioned script contains the name of the key vault. Default is `kv-fldemo`.
+    > Note: The AML workspace you created with the aforementioned script contains the name of the key vault. Default is `ws-secrets-fldemo`.
 
 3. With your newly created permissions, you can now create a secret to store the `kaggleusername`.
 

--- a/docs/real-world-examples/pneumonia.md
+++ b/docs/real-world-examples/pneumonia.md
@@ -46,7 +46,7 @@ Kaggle requires a username and an [API key](https://github.com/Kaggle/kaggle-api
     az keyvault set-policy -n <key-vault-name> --secret-permissions list set delete --object-id <object-id>
     ```
 
-    > Note: The AML workspace you created with the aforementioned script contains the name of the key vault. Default is `ws-secrets-fldemo`.
+    > Note: The AML workspace you created with the aforementioned script contains the name of the key vault. Default is `ws-shkv-fldemo`.
 
 3. With your newly created permissions, you can now create a secret to store the `kaggleusername`.
 

--- a/mlops/arm/open_sandbox_setup.json
+++ b/mlops/arm/open_sandbox_setup.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.14.85.62628",
-      "templateHash": "8213875226091941851"
+      "templateHash": "10965442046376289988"
     }
   },
   "parameters": {
@@ -117,7 +117,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.14.85.62628",
-              "templateHash": "9800239542873115852"
+              "templateHash": "1686050596943569961"
             }
           },
           "parameters": {
@@ -180,9 +180,9 @@
             },
             "keyVaultName": {
               "type": "string",
-              "defaultValue": "[format('kv-{0}', parameters('baseName'))]",
+              "defaultValue": "[format('ws-secrets-{0}', parameters('baseName'))]",
               "metadata": {
-                "description": "Name of the key vault resource"
+                "description": "Name of the workspace secrets store (shared keyvault) resource"
               }
             },
             "storageAccountName": {

--- a/mlops/arm/open_sandbox_setup.json
+++ b/mlops/arm/open_sandbox_setup.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.14.85.62628",
-      "templateHash": "10965442046376289988"
+      "templateHash": "7560492308759527952"
     }
   },
   "parameters": {
@@ -117,7 +117,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.14.85.62628",
-              "templateHash": "1686050596943569961"
+              "templateHash": "1072571431826254999"
             }
           },
           "parameters": {
@@ -180,7 +180,7 @@
             },
             "keyVaultName": {
               "type": "string",
-              "defaultValue": "[format('ws-secrets-{0}', parameters('baseName'))]",
+              "defaultValue": "[format('ws-shkv-{0}', parameters('baseName'))]",
               "metadata": {
                 "description": "Name of the workspace secrets store (shared keyvault) resource"
               }

--- a/mlops/arm/vnet_publicip_sandbox_aks_confcomp_setup.json
+++ b/mlops/arm/vnet_publicip_sandbox_aks_confcomp_setup.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.14.85.62628",
-      "templateHash": "14080767129914102191"
+      "templateHash": "9400061757828815648"
     }
   },
   "parameters": {
@@ -141,7 +141,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.14.85.62628",
-              "templateHash": "9800239542873115852"
+              "templateHash": "1686050596943569961"
             }
           },
           "parameters": {
@@ -204,9 +204,9 @@
             },
             "keyVaultName": {
               "type": "string",
-              "defaultValue": "[format('kv-{0}', parameters('baseName'))]",
+              "defaultValue": "[format('ws-secrets-{0}', parameters('baseName'))]",
               "metadata": {
-                "description": "Name of the key vault resource"
+                "description": "Name of the workspace secrets store (shared keyvault) resource"
               }
             },
             "storageAccountName": {

--- a/mlops/arm/vnet_publicip_sandbox_aks_confcomp_setup.json
+++ b/mlops/arm/vnet_publicip_sandbox_aks_confcomp_setup.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.14.85.62628",
-      "templateHash": "9400061757828815648"
+      "templateHash": "9662552762426929605"
     }
   },
   "parameters": {
@@ -141,7 +141,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.14.85.62628",
-              "templateHash": "1686050596943569961"
+              "templateHash": "1072571431826254999"
             }
           },
           "parameters": {
@@ -204,7 +204,7 @@
             },
             "keyVaultName": {
               "type": "string",
-              "defaultValue": "[format('ws-secrets-{0}', parameters('baseName'))]",
+              "defaultValue": "[format('ws-shkv-{0}', parameters('baseName'))]",
               "metadata": {
                 "description": "Name of the workspace secrets store (shared keyvault) resource"
               }

--- a/mlops/arm/vnet_publicip_sandbox_setup.json
+++ b/mlops/arm/vnet_publicip_sandbox_setup.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.14.85.62628",
-      "templateHash": "17536075077563434654"
+      "templateHash": "14162201911852613086"
     }
   },
   "parameters": {
@@ -166,7 +166,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.14.85.62628",
-              "templateHash": "9800239542873115852"
+              "templateHash": "1686050596943569961"
             }
           },
           "parameters": {
@@ -229,9 +229,9 @@
             },
             "keyVaultName": {
               "type": "string",
-              "defaultValue": "[format('kv-{0}', parameters('baseName'))]",
+              "defaultValue": "[format('ws-secrets-{0}', parameters('baseName'))]",
               "metadata": {
-                "description": "Name of the key vault resource"
+                "description": "Name of the workspace secrets store (shared keyvault) resource"
               }
             },
             "storageAccountName": {

--- a/mlops/arm/vnet_publicip_sandbox_setup.json
+++ b/mlops/arm/vnet_publicip_sandbox_setup.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.14.85.62628",
-      "templateHash": "14162201911852613086"
+      "templateHash": "29306935043037571"
     }
   },
   "parameters": {
@@ -166,7 +166,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.14.85.62628",
-              "templateHash": "1686050596943569961"
+              "templateHash": "1072571431826254999"
             }
           },
           "parameters": {
@@ -229,7 +229,7 @@
             },
             "keyVaultName": {
               "type": "string",
-              "defaultValue": "[format('ws-secrets-{0}', parameters('baseName'))]",
+              "defaultValue": "[format('ws-shkv-{0}', parameters('baseName'))]",
               "metadata": {
                 "description": "Name of the workspace secrets store (shared keyvault) resource"
               }

--- a/mlops/bicep/modules/azureml/open_azureml_workspace.bicep
+++ b/mlops/bicep/modules/azureml/open_azureml_workspace.bicep
@@ -36,7 +36,7 @@ param applicationInsightsName string = 'appi-${baseName}'
 param containerRegistryName string = replace('cr-${baseName}','-','') // replace because only alphanumeric characters are supported
 
 @description('Name of the workspace secrets store (shared keyvault) resource')
-param keyVaultName string = 'ws-secrets-${baseName}'
+param keyVaultName string = 'ws-shkv-${baseName}'
 
 @description('Name of the storage account resource')
 param storageAccountName string = replace('st-${baseName}','-','') // replace because only alphanumeric characters are supported

--- a/mlops/bicep/modules/azureml/open_azureml_workspace.bicep
+++ b/mlops/bicep/modules/azureml/open_azureml_workspace.bicep
@@ -35,8 +35,8 @@ param applicationInsightsName string = 'appi-${baseName}'
 @description('Name of the container registry resource')
 param containerRegistryName string = replace('cr-${baseName}','-','') // replace because only alphanumeric characters are supported
 
-@description('Name of the key vault resource')
-param keyVaultName string = 'kv-${baseName}'
+@description('Name of the workspace secrets store (shared keyvault) resource')
+param keyVaultName string = 'ws-secrets-${baseName}'
 
 @description('Name of the storage account resource')
 param storageAccountName string = replace('st-${baseName}','-','') // replace because only alphanumeric characters are supported


### PR DESCRIPTION
## Purpose

The keyvault that is attached to an AzureML workspace can enable users to read secrets as long as they have access to the workspace. To it's actually just a way to securely store workspace shared secrets, not something that should be used for production secrets.

In the future work on confidentiality, we'll need to create a "production keyvaut" external to the workspace. This PR goes this way by renaming the kv to reflect its function.

## What is the expected review turnaround time?

Urgency:
- [ ] High (needs review today)
- [x] Medium (needs review within a few days - most common)
- [ ] Low (can wait a week)

## Does this introduce a breaking change?

```
[ ] Yes
[x] No
```

## Pull Request Type

```
[ ] Bugfix
[ ] Feature
[x] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:
```