### PR TITLE
Remove Shared Access Key in storage biceps, update ARM accordingly

### DIFF
--- a/mlops/arm/open_aks_with_confcomp_storage_pair.json
+++ b/mlops/arm/open_aks_with_confcomp_storage_pair.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.14.85.62628",
-      "templateHash": "15133646902493684211"
+      "templateHash": "1089082292568179127"
     }
   },
   "parameters": {
@@ -163,7 +163,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.14.85.62628",
-              "templateHash": "8073065165220131475"
+              "templateHash": "3521838058917601730"
             }
           },
           "parameters": {
@@ -273,7 +273,7 @@
                 "allowBlobPublicAccess": false,
                 "allowCrossTenantReplication": false,
                 "allowedCopyScope": "PrivateLink",
-                "allowSharedKeyAccess": true,
+                "allowSharedKeyAccess": false,
                 "networkAcls": {
                   "copy": [
                     {

--- a/mlops/arm/open_compute_storage_pair.json
+++ b/mlops/arm/open_compute_storage_pair.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.14.85.62628",
-      "templateHash": "17130926876543764853"
+      "templateHash": "15405796131150436024"
     }
   },
   "parameters": {
@@ -169,7 +169,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.14.85.62628",
-              "templateHash": "8073065165220131475"
+              "templateHash": "3521838058917601730"
             }
           },
           "parameters": {
@@ -279,7 +279,7 @@
                 "allowBlobPublicAccess": false,
                 "allowCrossTenantReplication": false,
                 "allowedCopyScope": "PrivateLink",
-                "allowSharedKeyAccess": true,
+                "allowSharedKeyAccess": false,
                 "networkAcls": {
                   "copy": [
                     {

--- a/mlops/arm/sandbox_fl_confidential.json
+++ b/mlops/arm/sandbox_fl_confidential.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.14.85.62628",
-      "templateHash": "2937070433591051028"
+      "templateHash": "13457334997319729516"
     }
   },
   "parameters": {
@@ -132,7 +132,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.14.85.62628",
-              "templateHash": "1810000442779468320"
+              "templateHash": "16858099296982973929"
             }
           },
           "parameters": {
@@ -586,7 +586,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "0.14.85.62628",
-                      "templateHash": "7795565545239978732"
+                      "templateHash": "4272420941481803968"
                     }
                   },
                   "parameters": {
@@ -1664,7 +1664,7 @@
                             "_generator": {
                               "name": "bicep",
                               "version": "0.14.85.62628",
-                              "templateHash": "8073065165220131475"
+                              "templateHash": "3521838058917601730"
                             }
                           },
                           "parameters": {
@@ -1774,7 +1774,7 @@
                                 "allowBlobPublicAccess": false,
                                 "allowCrossTenantReplication": false,
                                 "allowedCopyScope": "PrivateLink",
-                                "allowSharedKeyAccess": true,
+                                "allowSharedKeyAccess": false,
                                 "networkAcls": {
                                   "copy": [
                                     {
@@ -2302,7 +2302,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "0.14.85.62628",
-                      "templateHash": "7795565545239978732"
+                      "templateHash": "4272420941481803968"
                     }
                   },
                   "parameters": {
@@ -3380,7 +3380,7 @@
                             "_generator": {
                               "name": "bicep",
                               "version": "0.14.85.62628",
-                              "templateHash": "8073065165220131475"
+                              "templateHash": "3521838058917601730"
                             }
                           },
                           "parameters": {
@@ -3490,7 +3490,7 @@
                                 "allowBlobPublicAccess": false,
                                 "allowCrossTenantReplication": false,
                                 "allowedCopyScope": "PrivateLink",
-                                "allowSharedKeyAccess": true,
+                                "allowSharedKeyAccess": false,
                                 "networkAcls": {
                                   "copy": [
                                     {

--- a/mlops/arm/sandbox_fl_eyesoff_cpu.json
+++ b/mlops/arm/sandbox_fl_eyesoff_cpu.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.14.85.62628",
-      "templateHash": "7196242836377076935"
+      "templateHash": "11924714516203580"
     }
   },
   "parameters": {
@@ -135,7 +135,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.14.85.62628",
-              "templateHash": "8256567375918972673"
+              "templateHash": "9557129114876216911"
             }
           },
           "parameters": {
@@ -626,7 +626,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "0.14.85.62628",
-                      "templateHash": "3636641920789338675"
+                      "templateHash": "5510539254768185390"
                     }
                   },
                   "parameters": {
@@ -1627,7 +1627,7 @@
                             "_generator": {
                               "name": "bicep",
                               "version": "0.14.85.62628",
-                              "templateHash": "8073065165220131475"
+                              "templateHash": "3521838058917601730"
                             }
                           },
                           "parameters": {
@@ -1737,7 +1737,7 @@
                                 "allowBlobPublicAccess": false,
                                 "allowCrossTenantReplication": false,
                                 "allowedCopyScope": "PrivateLink",
-                                "allowSharedKeyAccess": true,
+                                "allowSharedKeyAccess": false,
                                 "networkAcls": {
                                   "copy": [
                                     {
@@ -2278,7 +2278,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "0.14.85.62628",
-                      "templateHash": "3636641920789338675"
+                      "templateHash": "5510539254768185390"
                     }
                   },
                   "parameters": {
@@ -3279,7 +3279,7 @@
                             "_generator": {
                               "name": "bicep",
                               "version": "0.14.85.62628",
-                              "templateHash": "8073065165220131475"
+                              "templateHash": "3521838058917601730"
                             }
                           },
                           "parameters": {
@@ -3389,7 +3389,7 @@
                                 "allowBlobPublicAccess": false,
                                 "allowCrossTenantReplication": false,
                                 "allowedCopyScope": "PrivateLink",
-                                "allowSharedKeyAccess": true,
+                                "allowSharedKeyAccess": false,
                                 "networkAcls": {
                                   "copy": [
                                     {

--- a/mlops/arm/sandbox_fl_eyesoff_cpu_gpu.json
+++ b/mlops/arm/sandbox_fl_eyesoff_cpu_gpu.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.14.85.62628",
-      "templateHash": "10343613504660101171"
+      "templateHash": "4565096151290650712"
     }
   },
   "parameters": {
@@ -145,7 +145,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.14.85.62628",
-              "templateHash": "8256567375918972673"
+              "templateHash": "9557129114876216911"
             }
           },
           "parameters": {
@@ -636,7 +636,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "0.14.85.62628",
-                      "templateHash": "3636641920789338675"
+                      "templateHash": "5510539254768185390"
                     }
                   },
                   "parameters": {
@@ -1637,7 +1637,7 @@
                             "_generator": {
                               "name": "bicep",
                               "version": "0.14.85.62628",
-                              "templateHash": "8073065165220131475"
+                              "templateHash": "3521838058917601730"
                             }
                           },
                           "parameters": {
@@ -1747,7 +1747,7 @@
                                 "allowBlobPublicAccess": false,
                                 "allowCrossTenantReplication": false,
                                 "allowedCopyScope": "PrivateLink",
-                                "allowSharedKeyAccess": true,
+                                "allowSharedKeyAccess": false,
                                 "networkAcls": {
                                   "copy": [
                                     {
@@ -2288,7 +2288,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "0.14.85.62628",
-                      "templateHash": "3636641920789338675"
+                      "templateHash": "5510539254768185390"
                     }
                   },
                   "parameters": {
@@ -3289,7 +3289,7 @@
                             "_generator": {
                               "name": "bicep",
                               "version": "0.14.85.62628",
-                              "templateHash": "8073065165220131475"
+                              "templateHash": "3521838058917601730"
                             }
                           },
                           "parameters": {
@@ -3399,7 +3399,7 @@
                                 "allowBlobPublicAccess": false,
                                 "allowCrossTenantReplication": false,
                                 "allowedCopyScope": "PrivateLink",
-                                "allowSharedKeyAccess": true,
+                                "allowSharedKeyAccess": false,
                                 "networkAcls": {
                                   "copy": [
                                     {

--- a/mlops/arm/sandbox_fl_eyesoff_gpu.json
+++ b/mlops/arm/sandbox_fl_eyesoff_gpu.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.14.85.62628",
-      "templateHash": "6161125675608184459"
+      "templateHash": "7653425359951718666"
     }
   },
   "parameters": {
@@ -135,7 +135,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.14.85.62628",
-              "templateHash": "8256567375918972673"
+              "templateHash": "9557129114876216911"
             }
           },
           "parameters": {
@@ -626,7 +626,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "0.14.85.62628",
-                      "templateHash": "3636641920789338675"
+                      "templateHash": "5510539254768185390"
                     }
                   },
                   "parameters": {
@@ -1627,7 +1627,7 @@
                             "_generator": {
                               "name": "bicep",
                               "version": "0.14.85.62628",
-                              "templateHash": "8073065165220131475"
+                              "templateHash": "3521838058917601730"
                             }
                           },
                           "parameters": {
@@ -1737,7 +1737,7 @@
                                 "allowBlobPublicAccess": false,
                                 "allowCrossTenantReplication": false,
                                 "allowedCopyScope": "PrivateLink",
-                                "allowSharedKeyAccess": true,
+                                "allowSharedKeyAccess": false,
                                 "networkAcls": {
                                   "copy": [
                                     {
@@ -2278,7 +2278,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "0.14.85.62628",
-                      "templateHash": "3636641920789338675"
+                      "templateHash": "5510539254768185390"
                     }
                   },
                   "parameters": {
@@ -3279,7 +3279,7 @@
                             "_generator": {
                               "name": "bicep",
                               "version": "0.14.85.62628",
-                              "templateHash": "8073065165220131475"
+                              "templateHash": "3521838058917601730"
                             }
                           },
                           "parameters": {
@@ -3389,7 +3389,7 @@
                                 "allowBlobPublicAccess": false,
                                 "allowCrossTenantReplication": false,
                                 "allowedCopyScope": "PrivateLink",
-                                "allowSharedKeyAccess": true,
+                                "allowSharedKeyAccess": false,
                                 "networkAcls": {
                                   "copy": [
                                     {

--- a/mlops/arm/sandbox_fl_eyeson_cpu.json
+++ b/mlops/arm/sandbox_fl_eyeson_cpu.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.14.85.62628",
-      "templateHash": "15897301124001596848"
+      "templateHash": "6317521118238946348"
     }
   },
   "parameters": {
@@ -130,7 +130,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.14.85.62628",
-              "templateHash": "8256567375918972673"
+              "templateHash": "9557129114876216911"
             }
           },
           "parameters": {
@@ -621,7 +621,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "0.14.85.62628",
-                      "templateHash": "3636641920789338675"
+                      "templateHash": "5510539254768185390"
                     }
                   },
                   "parameters": {
@@ -1622,7 +1622,7 @@
                             "_generator": {
                               "name": "bicep",
                               "version": "0.14.85.62628",
-                              "templateHash": "8073065165220131475"
+                              "templateHash": "3521838058917601730"
                             }
                           },
                           "parameters": {
@@ -1732,7 +1732,7 @@
                                 "allowBlobPublicAccess": false,
                                 "allowCrossTenantReplication": false,
                                 "allowedCopyScope": "PrivateLink",
-                                "allowSharedKeyAccess": true,
+                                "allowSharedKeyAccess": false,
                                 "networkAcls": {
                                   "copy": [
                                     {
@@ -2273,7 +2273,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "0.14.85.62628",
-                      "templateHash": "3636641920789338675"
+                      "templateHash": "5510539254768185390"
                     }
                   },
                   "parameters": {
@@ -3274,7 +3274,7 @@
                             "_generator": {
                               "name": "bicep",
                               "version": "0.14.85.62628",
-                              "templateHash": "8073065165220131475"
+                              "templateHash": "3521838058917601730"
                             }
                           },
                           "parameters": {
@@ -3384,7 +3384,7 @@
                                 "allowBlobPublicAccess": false,
                                 "allowCrossTenantReplication": false,
                                 "allowedCopyScope": "PrivateLink",
-                                "allowSharedKeyAccess": true,
+                                "allowSharedKeyAccess": false,
                                 "networkAcls": {
                                   "copy": [
                                     {

--- a/mlops/arm/sandbox_fl_eyeson_cpu_gpu.json
+++ b/mlops/arm/sandbox_fl_eyeson_cpu_gpu.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.14.85.62628",
-      "templateHash": "9863015459061206917"
+      "templateHash": "2447224039146516399"
     }
   },
   "parameters": {
@@ -140,7 +140,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.14.85.62628",
-              "templateHash": "8256567375918972673"
+              "templateHash": "9557129114876216911"
             }
           },
           "parameters": {
@@ -631,7 +631,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "0.14.85.62628",
-                      "templateHash": "3636641920789338675"
+                      "templateHash": "5510539254768185390"
                     }
                   },
                   "parameters": {
@@ -1632,7 +1632,7 @@
                             "_generator": {
                               "name": "bicep",
                               "version": "0.14.85.62628",
-                              "templateHash": "8073065165220131475"
+                              "templateHash": "3521838058917601730"
                             }
                           },
                           "parameters": {
@@ -1742,7 +1742,7 @@
                                 "allowBlobPublicAccess": false,
                                 "allowCrossTenantReplication": false,
                                 "allowedCopyScope": "PrivateLink",
-                                "allowSharedKeyAccess": true,
+                                "allowSharedKeyAccess": false,
                                 "networkAcls": {
                                   "copy": [
                                     {
@@ -2283,7 +2283,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "0.14.85.62628",
-                      "templateHash": "3636641920789338675"
+                      "templateHash": "5510539254768185390"
                     }
                   },
                   "parameters": {
@@ -3284,7 +3284,7 @@
                             "_generator": {
                               "name": "bicep",
                               "version": "0.14.85.62628",
-                              "templateHash": "8073065165220131475"
+                              "templateHash": "3521838058917601730"
                             }
                           },
                           "parameters": {
@@ -3394,7 +3394,7 @@
                                 "allowBlobPublicAccess": false,
                                 "allowCrossTenantReplication": false,
                                 "allowedCopyScope": "PrivateLink",
-                                "allowSharedKeyAccess": true,
+                                "allowSharedKeyAccess": false,
                                 "networkAcls": {
                                   "copy": [
                                     {

--- a/mlops/arm/sandbox_fl_eyeson_gpu.json
+++ b/mlops/arm/sandbox_fl_eyeson_gpu.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.14.85.62628",
-      "templateHash": "14987410473731630751"
+      "templateHash": "5328259930051823197"
     }
   },
   "parameters": {
@@ -130,7 +130,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.14.85.62628",
-              "templateHash": "8256567375918972673"
+              "templateHash": "9557129114876216911"
             }
           },
           "parameters": {
@@ -621,7 +621,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "0.14.85.62628",
-                      "templateHash": "3636641920789338675"
+                      "templateHash": "5510539254768185390"
                     }
                   },
                   "parameters": {
@@ -1622,7 +1622,7 @@
                             "_generator": {
                               "name": "bicep",
                               "version": "0.14.85.62628",
-                              "templateHash": "8073065165220131475"
+                              "templateHash": "3521838058917601730"
                             }
                           },
                           "parameters": {
@@ -1732,7 +1732,7 @@
                                 "allowBlobPublicAccess": false,
                                 "allowCrossTenantReplication": false,
                                 "allowedCopyScope": "PrivateLink",
-                                "allowSharedKeyAccess": true,
+                                "allowSharedKeyAccess": false,
                                 "networkAcls": {
                                   "copy": [
                                     {
@@ -2273,7 +2273,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "0.14.85.62628",
-                      "templateHash": "3636641920789338675"
+                      "templateHash": "5510539254768185390"
                     }
                   },
                   "parameters": {
@@ -3274,7 +3274,7 @@
                             "_generator": {
                               "name": "bicep",
                               "version": "0.14.85.62628",
-                              "templateHash": "8073065165220131475"
+                              "templateHash": "3521838058917601730"
                             }
                           },
                           "parameters": {
@@ -3384,7 +3384,7 @@
                                 "allowBlobPublicAccess": false,
                                 "allowCrossTenantReplication": false,
                                 "allowedCopyScope": "PrivateLink",
-                                "allowSharedKeyAccess": true,
+                                "allowSharedKeyAccess": false,
                                 "networkAcls": {
                                   "copy": [
                                     {

--- a/mlops/arm/sandbox_minimal.json
+++ b/mlops/arm/sandbox_minimal.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.14.85.62628",
-      "templateHash": "11633454165432816420"
+      "templateHash": "15067557440241155431"
     }
   },
   "parameters": {
@@ -453,7 +453,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.14.85.62628",
-              "templateHash": "17130926876543764853"
+              "templateHash": "15405796131150436024"
             }
           },
           "parameters": {
@@ -617,7 +617,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "0.14.85.62628",
-                      "templateHash": "8073065165220131475"
+                      "templateHash": "3521838058917601730"
                     }
                   },
                   "parameters": {
@@ -727,7 +727,7 @@
                         "allowBlobPublicAccess": false,
                         "allowCrossTenantReplication": false,
                         "allowedCopyScope": "PrivateLink",
-                        "allowSharedKeyAccess": true,
+                        "allowSharedKeyAccess": false,
                         "networkAcls": {
                           "copy": [
                             {
@@ -1337,7 +1337,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.14.85.62628",
-              "templateHash": "17130926876543764853"
+              "templateHash": "15405796131150436024"
             }
           },
           "parameters": {
@@ -1501,7 +1501,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "0.14.85.62628",
-                      "templateHash": "8073065165220131475"
+                      "templateHash": "3521838058917601730"
                     }
                   },
                   "parameters": {
@@ -1611,7 +1611,7 @@
                         "allowBlobPublicAccess": false,
                         "allowCrossTenantReplication": false,
                         "allowedCopyScope": "PrivateLink",
-                        "allowSharedKeyAccess": true,
+                        "allowSharedKeyAccess": false,
                         "networkAcls": {
                           "copy": [
                             {

--- a/mlops/arm/vnet_compute_storage_pair.json
+++ b/mlops/arm/vnet_compute_storage_pair.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.14.85.62628",
-      "templateHash": "3636641920789338675"
+      "templateHash": "5510539254768185390"
     }
   },
   "parameters": {
@@ -1006,7 +1006,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.14.85.62628",
-              "templateHash": "8073065165220131475"
+              "templateHash": "3521838058917601730"
             }
           },
           "parameters": {
@@ -1116,7 +1116,7 @@
                 "allowBlobPublicAccess": false,
                 "allowCrossTenantReplication": false,
                 "allowedCopyScope": "PrivateLink",
-                "allowSharedKeyAccess": true,
+                "allowSharedKeyAccess": false,
                 "networkAcls": {
                   "copy": [
                     {

--- a/mlops/arm/vnet_publicip_sandbox_aks_confcomp_setup.json
+++ b/mlops/arm/vnet_publicip_sandbox_aks_confcomp_setup.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.14.85.62628",
-      "templateHash": "1810000442779468320"
+      "templateHash": "16858099296982973929"
     }
   },
   "parameters": {
@@ -459,7 +459,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.14.85.62628",
-              "templateHash": "7795565545239978732"
+              "templateHash": "4272420941481803968"
             }
           },
           "parameters": {
@@ -1537,7 +1537,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "0.14.85.62628",
-                      "templateHash": "8073065165220131475"
+                      "templateHash": "3521838058917601730"
                     }
                   },
                   "parameters": {
@@ -1647,7 +1647,7 @@
                         "allowBlobPublicAccess": false,
                         "allowCrossTenantReplication": false,
                         "allowedCopyScope": "PrivateLink",
-                        "allowSharedKeyAccess": true,
+                        "allowSharedKeyAccess": false,
                         "networkAcls": {
                           "copy": [
                             {
@@ -2175,7 +2175,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.14.85.62628",
-              "templateHash": "7795565545239978732"
+              "templateHash": "4272420941481803968"
             }
           },
           "parameters": {
@@ -3253,7 +3253,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "0.14.85.62628",
-                      "templateHash": "8073065165220131475"
+                      "templateHash": "3521838058917601730"
                     }
                   },
                   "parameters": {
@@ -3363,7 +3363,7 @@
                         "allowBlobPublicAccess": false,
                         "allowCrossTenantReplication": false,
                         "allowedCopyScope": "PrivateLink",
-                        "allowSharedKeyAccess": true,
+                        "allowSharedKeyAccess": false,
                         "networkAcls": {
                           "copy": [
                             {

--- a/mlops/arm/vnet_publicip_sandbox_setup.json
+++ b/mlops/arm/vnet_publicip_sandbox_setup.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.14.85.62628",
-      "templateHash": "8256567375918972673"
+      "templateHash": "9557129114876216911"
     }
   },
   "parameters": {
@@ -496,7 +496,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.14.85.62628",
-              "templateHash": "3636641920789338675"
+              "templateHash": "5510539254768185390"
             }
           },
           "parameters": {
@@ -1497,7 +1497,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "0.14.85.62628",
-                      "templateHash": "8073065165220131475"
+                      "templateHash": "3521838058917601730"
                     }
                   },
                   "parameters": {
@@ -1607,7 +1607,7 @@
                         "allowBlobPublicAccess": false,
                         "allowCrossTenantReplication": false,
                         "allowedCopyScope": "PrivateLink",
-                        "allowSharedKeyAccess": true,
+                        "allowSharedKeyAccess": false,
                         "networkAcls": {
                           "copy": [
                             {
@@ -2148,7 +2148,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.14.85.62628",
-              "templateHash": "3636641920789338675"
+              "templateHash": "5510539254768185390"
             }
           },
           "parameters": {
@@ -3149,7 +3149,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "0.14.85.62628",
-                      "templateHash": "8073065165220131475"
+                      "templateHash": "3521838058917601730"
                     }
                   },
                   "parameters": {
@@ -3259,7 +3259,7 @@
                         "allowBlobPublicAccess": false,
                         "allowCrossTenantReplication": false,
                         "allowedCopyScope": "PrivateLink",
-                        "allowSharedKeyAccess": true,
+                        "allowSharedKeyAccess": false,
                         "networkAcls": {
                           "copy": [
                             {

--- a/mlops/bicep/modules/storages/new_blob_storage_datastore.bicep
+++ b/mlops/bicep/modules/storages/new_blob_storage_datastore.bicep
@@ -72,7 +72,7 @@ resource storage 'Microsoft.Storage/storageAccounts@2022-05-01' = {
     allowedCopyScope: 'PrivateLink'
 
     // Indicates whether the storage account permits requests to be authorized with the account access key via Shared Key.
-    allowSharedKeyAccess: true
+    allowSharedKeyAccess: false // we're using UAI anyway, no need for shared key access
 
 
     // Network rule set


### PR DESCRIPTION
This parameter is not needed since we're using UAI/RBAC to control access.

https://learn.microsoft.com/en-us/azure/storage/common/shared-key-authorization-prevent?toc=%2Fazure%2Fstorage%2Fblobs%2Ftoc.json&bc=%2Fazure%2Fstorage%2Fblobs%2Fbreadcrumb%2Ftoc.json&tabs=portal#understand-how-disallowing-shared-key-affects-sas-tokens